### PR TITLE
MORPH-10741: Fix image sync accumulation and slow dataset provider queries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,7 @@ tasks.register('publishToMorpheus') {
 	tasks.findByName('moveToPlugin').mustRunAfter 'shadowJar'
 }
 
-test {
+tasks.withType(Test).configureEach {
 	useJUnitPlatform()  // Required for Spock 2.x
 	testLogging {
 		exceptionFormat = 'full'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/groovy/com/morpheusdata/nutanix/prismelement/plugin/cloud/sync/ImagesSync.groovy
+++ b/src/main/groovy/com/morpheusdata/nutanix/prismelement/plugin/cloud/sync/ImagesSync.groovy
@@ -81,6 +81,7 @@ class ImagesSync {
 	}
 
 	private addMissingVirtualImageLocations(Collection<Map> addItems) {
+		def externalIds = (addItems.collect { it.uuid } + addItems.collect { it.vmDiskId }).findAll { it }.unique()
 		def existingRecords = morpheusContext.async.virtualImage.listIdentityProjections(
 			new DataQuery()
 				.withFilters(
@@ -90,7 +91,7 @@ class ImagesSync {
 						new DataFilter('owner.id', '==', cloud.owner.id)
 					),
 					new DataOrFilter(
-						new DataFilter('externalId', 'in', (addItems.collect { it.uuid } + addItems.collect { it.vmDiskId }).unique()),
+						new DataFilter('externalId', 'in', externalIds),
 						new DataFilter('name', 'in', addItems.collect { it.name })
 					)
 				)
@@ -100,6 +101,8 @@ class ImagesSync {
 		syncTask.addMatchFunction { VirtualImageIdentityProjection existingItem, Map cloudItem ->
 			cloudItem.uuid == existingItem.externalId
 				|| cloudItem?.vmDiskId == existingItem.externalId
+		}.addMatchFunction { VirtualImageIdentityProjection existingItem, Map cloudItem ->
+			existingItem.name == cloudItem.name
 		}.onDelete { removeItems ->
 			// noop
 		}.onUpdate { List<SyncTask.UpdateItem<VirtualImage, Map>> updateItems ->

--- a/src/main/groovy/com/morpheusdata/nutanix/prismelement/plugin/dataset/NutanixPrismElementProvisionImageDatasetProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/nutanix/prismelement/plugin/dataset/NutanixPrismElementProvisionImageDatasetProvider.groovy
@@ -67,7 +67,8 @@ class NutanixPrismElementProvisionImageDatasetProvider extends AbstractDatasetPr
 			filter = new DataFilter("userUploaded", true)
 		}
 
-		return morpheusContext.async.virtualImage.list(
+		// Use identity projections to avoid hydrating full VirtualImage GORM objects
+		return morpheusContext.async.virtualImage.listIdentityProjections(
 			new DataQuery()
 				.withFilters(
 					new DataOrFilter(
@@ -82,7 +83,12 @@ class NutanixPrismElementProvisionImageDatasetProvider extends AbstractDatasetPr
 					),
 					filter,
 				).withSort('name')
-		)
+		).map { projection ->
+			def vi = new VirtualImage()
+			vi.id = projection.id
+			vi.name = projection.name
+			return vi
+		}
 	}
 
 	/**

--- a/src/main/groovy/com/morpheusdata/nutanix/prismelement/plugin/dataset/NutanixPrismElementVirtualImageDatasetProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/nutanix/prismelement/plugin/dataset/NutanixPrismElementVirtualImageDatasetProvider.groovy
@@ -53,11 +53,12 @@ class NutanixPrismElementVirtualImageDatasetProvider extends AbstractDatasetProv
 	Observable<VirtualImage> list(DatasetQuery query) {
 		Long cloudId = query.get("zoneId")?.toLong()
 		Long accountId = query.get("accountId")?.toLong()
+
 		def listQuery = new DataQuery()
 			.withFilters(
 				new DataOrFilter(
 					new DataFilter('visibility', 'public'),
-					new DataFilter('accounts.id', null), // if there are no accounts associated
+					new DataFilter('accounts.id', null),
 					new DataFilter('accounts.id', accountId),
 					new DataFilter('owner.id', accountId),
 				),
@@ -105,7 +106,14 @@ class NutanixPrismElementVirtualImageDatasetProvider extends AbstractDatasetProv
 				),
 			)
 		}
-		return morpheusContext.async.virtualImage.list(listQuery)
+		// Use identity projections to avoid hydrating full VirtualImage GORM objects (87 columns).
+		// Callers only use name+id via listOptions().
+		return morpheusContext.async.virtualImage.listIdentityProjections(listQuery).map { projection ->
+			def vi = new VirtualImage()
+			vi.id = projection.id
+			vi.name = projection.name
+			return vi
+		}
 	}
 
 	/**


### PR DESCRIPTION
 ### Problem
 Two related issues were causing degraded behavior in Nutanix Prism Element:
 
 1. **Duplicate VirtualImage accumulation in ImagesSync** – The inner `SyncTask` was creating new `VirtualImageLocation` records for images it found by name but with a different `externalId`, rather than updating the existing entry. Over 
time this caused unbounded location accumulation.
 
 2. **Extremely slow image option sources** – `NutanixPrismElementVirtualImageDatasetProvider` and `NutanixPrismElementProvisionImageDatasetProvider` were calling `virtualImage.list()`, which hydrates full GORM domain objects (87 columns 
each). For ~1,000 images this took ~10 seconds per call.
 
 ### Changes
 - **ImagesSync**: Added a name-based fallback match function so existing `VirtualImage` records found by name (but differing `externalId`) have their locations updated instead of spawning duplicates. Also added null filtering when 
extracting `externalId`s for cleaner queries.
 - **Dataset providers**: Replaced `virtualImage.list()` with `virtualImage.listIdentityProjections()` in both dataset providers, returning lightweight Hibernate column projections instead of fully hydrated domain objects.